### PR TITLE
fix: decode integer types to i64

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -185,7 +185,7 @@ async fn select(
                         }
                     }
                     "INT" | "NUMBER" | "INTEGER" | "BIGINT" | "INT8" => {
-                        JsonValue::Number(row.get::<u32, usize>(i).into())
+                        JsonValue::Number(row.get::<i64, usize>(i).into())
                     }
                     // "JSON" => JsonValue::Object(row.get(i)),
                     "BLOB" => JsonValue::Array(


### PR DESCRIPTION
the current u32 type is a) too small and b) doesn't handle negative values. For example sqlite's (only) number type is i64, so trying to get numbers outside the u32 range will crash the program. This can easily occur because we insert it as i64.

This shouldn't impact performance, because the u32 was converted to i64 anyway (or actually u64 in this case) inside `serde_json::Value`.