### PR TITLE
Close all database pools when the app exits

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -15,7 +15,7 @@ use sqlx::{
 use tauri::{
   command,
   plugin::{Plugin, Result as PluginResult},
-  AppHandle, Invoke, Manager, Runtime, State,
+  AppHandle, Invoke, Manager, Runtime, State, RunEvent,
 };
 use tokio::sync::Mutex;
 
@@ -346,5 +346,17 @@ impl<R: Runtime> Plugin<R> for TauriSql<R> {
 
   fn extend_api(&mut self, message: Invoke<R>) {
     (self.invoke_handler)(message)
+  }
+
+  fn on_event(&mut self, app: &AppHandle<R>, event: &RunEvent) {
+    if let RunEvent::Exit = event {
+      tauri::async_runtime::block_on(async move {
+        let instances = &*app.state::<DbInstances>();
+        let instances = instances.0.lock().await;
+        for value in instances.values() {
+          value.close().await;
+        }
+      });
+    } 
   }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -15,7 +15,7 @@ use sqlx::{
 use tauri::{
   command,
   plugin::{Plugin, Result as PluginResult},
-  AppHandle, Invoke, Manager, Runtime, State, RunEvent,
+  AppHandle, Invoke, Manager, RunEvent, Runtime, State,
 };
 use tokio::sync::Mutex;
 
@@ -357,6 +357,6 @@ impl<R: Runtime> Plugin<R> for TauriSql<R> {
           value.close().await;
         }
       });
-    } 
+    }
   }
 }


### PR DESCRIPTION
Databases are known to be resilient services, however, it does not mean that the database clients should disregard common protocols when interacting with the database. In particular, it is important to cleanly close database connections when they are no longer needed.

This may be a quality of life improvement for most database. However, for the SQLite it could be especially important to cleanly close the database connection as it runs in-process with the client. In particular, when SQLite is running in the WAL-mode, it would maintain additional `my.db-wal` and `my.db-shm` files which are normally deleted, when the database connection is closed. In the current implementation the files remain on disk due to the connection not being closed properly.

This PR makes sure that all outstanding database connections are closed with a lifecycle event `RunEvent::Exit` happens.

Fixes tauri-apps/plugins-workspace#186